### PR TITLE
Filter by Period Option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv
+/venv
+__pycache__
+.sesskey

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 git clone https://github.com/scottyeager/peppermint.git
 
 cd peppermint
-mkdir venv
 python3 -m venv venv
 source venv/bin/activate
 pip install python-fasthtml requests grid3

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ git clone https://github.com/scottyeager/peppermint.git
 cd peppermint
 mkdir venv
 python3 -m venv venv
+source venv/bin/activate
 pip install python-fasthtml requests grid3
 
 python3 main.py

--- a/main.py
+++ b/main.py
@@ -7,26 +7,34 @@ import grid3.network
 mainnet = grid3.network.GridNetwork()
 app, rt = fast_app(live=True)
 
-# Keep a cash of known receipts, keyed by hash. Ideally we'd also keep record of which node ids have been queried and when, to know if there's a possibility of more recipts we didn't cache yet
+# Keep a cache of known receipts, keyed by hash. Ideally we'd also keep record of which node ids have been queried and when, to know if there's a possibility of more receipts we didn't cache yet
 receipts = {}
-
 
 @rt("/")
 def get():
     return render_main()
 
-
 @rt("/{select}/{id_input}")
-def get(req, select: str, id_input: int):
+@rt("/{select}/{id_input}/{filter_option}")
+def get(req, select: str, id_input: int, filter_option: str = None):
     if select == "node":
         results = [render_receipts(id_input)]
     elif select == "farm":
         nodes = mainnet.graphql.nodes(["nodeID"], farmID_eq=id_input)
         node_ids = sorted([node["nodeID"] for node in nodes])
         results = []
-        for node in node_ids:
-            results.append(H2(f"Node {node}"))
-            results.append(render_receipts(node))
+        if filter_option == "nodes":
+            for node in node_ids:
+                results.append(H2(f"Node {node}"))
+                results.append(render_receipts(node))
+        elif filter_option == "periods":
+            # Implement period filtering logic here
+            results.append(H2("Period filtering not implemented yet"))
+        else:
+            # Default behavior when no filter is selected
+            for node in node_ids:
+                results.append(H2(f"Node {node}"))
+                results.append(render_receipts(node))
 
     has_result = False
     for result in results:
@@ -39,8 +47,7 @@ def get(req, select: str, id_input: int):
     if "hx-request" in req.headers:
         return results
     else:
-        return render_main(select, id_input, results)
-
+        return render_main(select, id_input, results, filter_option)
 
 @rt("/node/{node_id}/{rhash}")
 def get(node_id: int, rhash: str):
@@ -53,11 +60,9 @@ def get(node_id: int, rhash: str):
 
     return render_main(id_input=node_id, result=details)
 
-
 @rt("/details")
 def get(rhash: str):
     return render_details(rhash)
-
 
 def process_receipt(receipt):
     # Flatten receipts so the type is an attribute
@@ -68,7 +73,6 @@ def process_receipt(receipt):
         r = receipt["Fixup"]
         r["type"] = "Fixup"
     return r
-
 
 def render_details(rhash):
     if rhash not in receipts:
@@ -90,8 +94,8 @@ def render_details(rhash):
         ),
     ]
 
-
-def render_main(select="node", id_input=None, result=""):
+def render_main(select="node", id_input=None, result="", filter_option=None):
+    farm_selected = select == "farm"
     return Titled(
         "Fetch Minting Receipts",
         Form(
@@ -103,7 +107,8 @@ def render_main(select="node", id_input=None, result=""):
             oninput="""
                     const sel = this.elements.select.value;
                     const id = this.elements.id_input.value;
-                    const path = '/' + sel + '/' + id;
+                    const filter = this.elements.filter_select ? this.elements.filter_select.value : '';
+                    const path = '/' + sel + '/' + id + (filter ? '/' + filter : '');
                     this.setAttribute('hx-get', path);
                     this.setAttribute('hx-push-url', path);
                     htmx.process(this);
@@ -116,8 +121,17 @@ def render_main(select="node", id_input=None, result=""):
                             child.removeAttribute('selected')
                         }
                     }
+                    if (this.elements.filter_select) {
+                        for (child of this.elements.filter_select.children){
+                            if (child.value == filter) {
+                                child.setAttribute('selected', 'selected')
+                            } else {
+                                child.removeAttribute('selected')
+                            }
+                        }
+                    }
                     this.elements.id_input.getAttribute('value')
-                        """,
+                    """,
         )(
             Div(
                 Div(
@@ -135,6 +149,16 @@ def render_main(select="node", id_input=None, result=""):
                         Option("Node ID", value="node", selected=select == "node"),
                         Option("Farm ID", value="farm", selected=select == "farm"),
                         id="select",
+                        onchange="toggleFilterOptions(this.value)"
+                    ),
+                    style="display: inline-block",
+                ),
+                Div(
+                    Select(
+                        Option("Filter by Node IDs", value="nodes", selected=filter_option == "nodes"),
+                        Option("Filter by Periods", value="periods", selected=filter_option == "periods"),
+                        id="filter_select",
+                        style="display: none" if not farm_selected else "inline-block"
                     ),
                     style="display: inline-block",
                 ),
@@ -155,8 +179,17 @@ def render_main(select="node", id_input=None, result=""):
             }
             """
         ),
+        Script("""
+            function toggleFilterOptions(value) {
+                var filterSelect = document.getElementById('filter_select');
+                if (value === 'farm') {
+                    filterSelect.style.display = 'inline-block';
+                } else {
+                    filterSelect.style.display = 'none';
+                }
+            }
+        """)
     )
-
 
 def render_receipts(node_id):
     if node_id:
@@ -184,7 +217,6 @@ def render_receipts(node_id):
             rows.append(render_receipt(rhash, receipt))
     return Table(*rows)
 
-
 def render_receipt(rhash, r, details=True):
     uptime = round(r["measured_uptime"] / (30.45 * 24 * 60 * 60) * 100, 2)
     if details:
@@ -204,7 +236,6 @@ def render_receipt(rhash, r, details=True):
         Td(r["reward"]["tft"] / 1e7),
     )
 
-
 def render_receipt_row2(r):
     return [
         Tr(
@@ -221,7 +252,6 @@ def render_receipt_row2(r):
         ),
     ]
 
-
 def receipt_header():
     return Tr(
         Th(Strong("Period Start")),
@@ -229,6 +259,5 @@ def receipt_header():
         Th(Strong("Uptime")),
         Th(Strong("TFT Minted")),
     )
-
 
 serve()


### PR DESCRIPTION
# Related Issue

- #1 

# Status

- Done

# Work Done

- Added .gitignore for venv
- Fixed readme steps and simplified steps
- Added filter button
- Added a page Filter by periods

# Specs

- Can now filter by node (default) or by period
- Periods are organized from latest to oldest
- We show all the nodes per farm per period
- Periods show the period name with most days in month, e.g. 31 may to 01 July is June 2024
- We check the end of a period to group the periods, as start of period change for new nodes

# Screenshots


![image](https://github.com/user-attachments/assets/181e6007-fd7f-4d72-974e-db05749142ce)



![image](https://github.com/user-attachments/assets/7b2caa53-a038-47da-b21f-1a462b192155)

